### PR TITLE
Feature/sequence labeling model

### DIFF
--- a/kashgari/tasks/seq_labeling/models.py
+++ b/kashgari/tasks/seq_labeling/models.py
@@ -16,7 +16,7 @@ from keras.models import Model
 
 from kashgari.layers import LSTMLayer
 from kashgari.tasks.seq_labeling.base_model import SequenceLabelingModel
-from kashgari.utils.crf import CRF, crf_loss, crf_accuracy
+from kashgari.utils.crf import CRF, crf_loss as kashgari_crf_loss, crf_accuracy as kashgari_crf_accuracy
 
 
 class CNNLSTMModel(SequenceLabelingModel):
@@ -149,22 +149,22 @@ class BLSTMCRFModel(SequenceLabelingModel):
             }
         },
         'compile_params': {
-            'loss': 'crf_loss',
+            'loss': 'kashgari_crf_loss',
             # 'optimizer': 'adam',
-            'metrics': ['crf_accuracy']
+            'metrics': ['kashgari_crf_accuracy']
         }
     }
 
     def build_model(self):
         loss = self.hyper_parameters['compile_params']['loss']
-        if loss == 'crf_loss':
-            loss = crf_loss
+        if loss.startswith('kashgari'):
+            loss = eval(loss)
 
         metrics = self.hyper_parameters['compile_params']['metrics']
         new_metrics = []
         for met in metrics:
-            if met == 'crf_accuracy':
-                new_metrics.append(crf_accuracy)
+            if met.startswith('kashgari') :
+                new_metrics.append(eval(met))
             else:
                 new_metrics.append(met)
         metrics = new_metrics

--- a/tests/test_classifier_models.py
+++ b/tests/test_classifier_models.py
@@ -95,7 +95,7 @@ class TestBLSTMModelModelBasic(unittest.TestCase):
         embedding = EmbeddingManager.get_w2v()
         w2v_model = self.model_class(embedding)
         w2v_model.fit(train_x, train_y, epochs=1)
-        assert len(w2v_model.label2idx) == 4
+        assert len(w2v_model.label2idx) == 3
         assert len(w2v_model.token2idx) > 4
 
         sentence = list('语言学包含了几种分支领域。')
@@ -121,7 +121,7 @@ class TestAllCNNModelModel(unittest.TestCase):
 
     def test_build(self):
         self.model.fit(train_x, train_y, epochs=1)
-        assert len(self.model.label2idx) == 4
+        assert len(self.model.label2idx) == 3
         assert len(self.model.token2idx) > 4
 
     def test_fit(self):
@@ -181,7 +181,7 @@ class TestAllCNNModelModel(unittest.TestCase):
         embedding = EmbeddingManager.get_w2v()
         w2v_model = self.model_class(embedding)
         w2v_model.fit(train_x, train_y, epochs=1)
-        assert len(w2v_model.label2idx) == 4
+        assert len(w2v_model.label2idx) == 3
         assert len(w2v_model.token2idx) > 4
 
         sentence = list('语言学包含了几种分支领域。')


### PR DESCRIPTION
1. Leave `eval` in code because `ast.literal_eval` is not suitable here. It cannot eval module names at all.
1. Slightly change to seq model definition, allowing to accept more self-defined loss and accuracy function in future.
1. Correct those `assert` lines in unit test since no pad label in label set any more. 