### PR TITLE
Update base_model.py

### DIFF
--- a/kashgari/tasks/classification/base_model.py
+++ b/kashgari/tasks/classification/base_model.py
@@ -184,6 +184,7 @@ class ClassificationModel(BaseModel):
                     target_x.append(x[start_index: end_index])
                 target_y = y_data[start_index: end_index]
                 if len(target_x[0]) == 0:
+                    target_x.pop()
                     for x in x_data:
                         target_x.append(x[0: batch_size])
                     target_y = y_data[0: batch_size]


### PR DESCRIPTION
修改了当样本数是batch_size整数倍时的处理操作.
当我使用分类的 CNNModel 时，训练集的样本数是120000，调用fit方法，报错。
原因是120000 是 batch_size(64) 的整数倍，多了一个page，代码在判断 target_x[0] 为空后，直接 append 了一个批次的样本，但是实际上 target_x[0] 仍然为空，因此我加了 pop 操作。