### PR TITLE
Export SavedModel for Serving

### DIFF
--- a/kashgari/tasks/base_model.py
+++ b/kashgari/tasks/base_model.py
@@ -11,11 +11,12 @@
 from typing import Dict, Any, List, Optional, Union, Tuple
 
 import os
+import time
 import json
 import pathlib
 import logging
 import numpy as np
-from tensorflow import keras
+from tensorflow import keras, saved_model
 from kashgari import utils
 from kashgari.embeddings import BareEmbedding
 from kashgari.embeddings.base_embedding import Embedding
@@ -286,6 +287,22 @@ class BaseModel(object):
 
         self.tf_model.save_weights(os.path.join(model_path, 'model.h5'))
         logging.info('model saved to {}'.format(os.path.abspath(model_path)))
+
+    def export(self, export_path: str, inputs: Optional[Dict] = None, outputs: Optional[Dict] = None):
+        pathlib.Path(export_path).mkdir(exist_ok=True, parents=True)
+
+        ts = round(time.time())
+        export_path = os.path.join(export_path, str(ts))
+
+        if inputs is None:
+            inputs = {i.name: i for i in self.tf_model.inputs}
+        if outputs is None:
+            outputs = {o.name: o for o in self.tf_model.outputs}
+        sess = keras.backend.get_session()
+        saved_model.simple_save(session=sess,
+                                export_dir=export_path,
+                                inputs=inputs,
+                                outputs=outputs)
 
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ __description__ = 'Simple, Keras-powered multilingual NLP framework,' \
                   'Includes BERT, GPT-2 and word2vec embedding.'
 
 __version__ = find_version('kashgari', 'version.py')
-README = (HERE / "README.md").read_text()
+README = (HERE / "README.md").read_text(encoding='utf-8')
 
 with codecs.open('requirements.txt', 'r', 'utf8') as reader:
     install_requires = list(map(lambda x: x.strip(), reader.readlines()))


### PR DESCRIPTION
```python
from kashgari.corpus import SMP2018ECDTCorpus
from kashgari.tasks.classification import BLSTMModel

x_data, y_data = SMP2018ECDTCorpus.load_data()
classifier = BLSTMModel()
classifier.fit(x_data, y_data)
# export saved model to ./savedmodels/<timestamp>/
classifier.export('./savedmodels')
```

```shell
saved_model_cli show --dir /path/to/saved_models/1559562438/ --tag_set serve --signature_def serving_default
# Output:
# The given SavedModel SignatureDef contains the following input(s):
#  inputs['input:0'] tensor_info:
#       dtype: DT_FLOAT
#       shape: (-1, 15)
#       name: input:0
# The given SavedModel SignatureDef contains the following output(s):
#   outputs['dense/Softmax:0'] tensor_info:
#       dtype: DT_FLOAT
#       shape: (-1, 32)
#       name: dense/Softmax:0
# Method name is: tensorflow/serving/predict

tensorflow_model_server --rest_api_port=9000 --model_name=blstm --model_base_path=/path/to/saved_models/ --enable_batching=true
# Output:
# 2019-06-03 08:28:56.639941: I tensorflow_serving/core/loader_harness.cc:86] Successfully loaded servable version {name: blstm version: 1559562438}
# 2019-06-03 08:28:56.645217: I tensorflow_serving/model_servers/server.cc:324] Running gRPC ModelServer at 0.0.0.0:8500 ...
# 2019-06-03 08:28:56.647192: I tensorflow_serving/model_servers/server.cc:344] Exporting HTTP/REST API at:localhost:9000 ...

curl -H "Content-type: application/json" -X POST -d '{"instances": [{"input:0": [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]}]}'  "http://localhost:9000/v1/models/blstm:predict"
# Output:
# {
#     "predictions": [[5.76590492e-06, 0.0334293731, 9.58459859e-05, 0.00066432351, 0.500331104, 0.0521887243, 0.000985755469, 0.000161868113, 0.00147783163, 0.0171929933, 0.00085421023, 0.00599030638, 1.79303879e-05, 0.00050331495, 3.7246391e-05, 3.13154237e-06, 0.0201187711, 0.000672292779, 0.000196203022, 4.57693459e-05, 2.69985958e-06, 8.66179619e-07, 1.03102286e-06, 3.53154815e-06, 0.0478210114, 0.00725555047, 0.000683069753, 0.262197495, 4.151143e-05, 0.046125982, 2.19863551e-07, 0.000894303957]
#     ]
# }
```


