### PR TITLE
fixbug:raise InvalidArgumentError when using convert_to_multi_gpu_model

### DIFF
--- a/kashgari/utils.py
+++ b/kashgari/utils.py
@@ -19,7 +19,7 @@ import tensorflow as tf
 from kashgari import custom_objects
 from kashgari.tasks.base_model import BaseModel
 from kashgari.embeddings.base_embedding import Embedding
-from typing import List
+from typing import List, Union
 
 
 def unison_shuffled_copies(a, b):
@@ -75,9 +75,13 @@ def convert_to_tpu_model(model: BaseModel,
 
 def convert_to_multi_gpu_model(model: BaseModel,
                                gpus: int,
-                               cpu_merge: bool,
-                               cpu_relocation: bool):
+                               x: List[List[str]],
+                               y: Union[List[List[str]], List[str]],
+                               cpu_merge: bool = True,
+                               cpu_relocation: bool = False):
+    model.embedding.analyze_corpus(x, y)
     with custom_object_scope():
+        model.build_model_arc()
         multi_gpu_model = tf.keras.utils.multi_gpu_model(model.tf_model,
                                                          gpus,
                                                          cpu_merge=cpu_merge,


### PR DESCRIPTION
## Reproduce:
```python
import logging
logging.basicConfig(level=logging.DEBUG)
import kashgari
from kashgari.embeddings import BERTEmbedding
from kashgari.corpus import ChineseDailyNerCorpus
from kashgari.tasks.labeling import BLSTMModel
from kashgari.utils import convert_to_multi_gpu_model

train_x, train_y = ChineseDailyNerCorpus.load_data('train', shuffle=False)
test_x, test_y = ChineseDailyNerCorpus.load_data('test', shuffle=False)
valid_x, valid_y = ChineseDailyNerCorpus.load_data('valid', shuffle=False)

train_count = int(len(train_y)*0.1)
test_count = int(len(test_y)*0.1)
valid_count = int(len(valid_x)*0.1)

train_x, train_y = train_x[:train_count], train_y[:train_count]
test_x, test_y = test_x[:test_count], test_y[:test_count]
valid_x, valid_y = valid_x[:valid_count], valid_y[:valid_count]

embedding = BERTEmbedding('/home/hahahu/projects/models/bert-base-chinese', task=kashgari.LABELING, sequence_length=100, layer_nums=4)
model = BLSTMModel(embedding)

model.build_model(train_x, train_y)
model = convert_to_multi_gpu_model(model, 2, True, False)
model.fit(train_x, train_y, valid_x, valid_y, batch_size=64, epochs=10)

model.evaluate(test_x, test_y, batch_size=512, debug_info=True)
```
## Traceback:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/hahahu/projects/scripts/Kashgari/kashgari/tasks/base_model.py", line 170, in fit
    **fit_kwargs)
  File "/usr/local/environment/anaconda3/lib/python3.6/site-packages/tensorflow/python/keras/engine/training.py", line 880, in fit
    validation_steps=validation_steps)
  File "/usr/local/environment/anaconda3/lib/python3.6/site-packages/tensorflow/python/keras/engine/training_arrays.py", line 329, in model_iteration
    batch_outs = f(ins_batch)
  File "/usr/local/environment/anaconda3/lib/python3.6/site-packages/tensorflow/python/keras/backend.py", line 3076, in __call__
    run_metadata=self.run_metadata)
  File "/usr/local/environment/anaconda3/lib/python3.6/site-packages/tensorflow/python/client/session.py", line 1439, in __call__
    run_metadata_ptr)
  File "/usr/local/environment/anaconda3/lib/python3.6/site-packages/tensorflow/python/framework/errors_impl.py", line 528, in __exit__
    c_api.TF_GetCode(self.status.status))
tensorflow.python.framework.errors_impl.InvalidArgumentError: You must feed a value for placeholder tensor 'activation_target' with dtype float and shape [?,?,?]
	 [[{{node activation_target}}]]
	 [[{{node ConstantFoldingCtrl/loss_2/activation_loss/broadcast_weights/assert_broadcastable/AssertGuard/Switch_0}}]]
```
## Solved:
In this test codes, calling `model.compile(...)` before the `utils.convert_to_multi_gpu_model(...)` will trigger this bug. So I tried to rebuild the model architectural in `utils.convert_to_multi_gpu_model(...)` to avoid this problem.
```python
import logging
logging.basicConfig(level=logging.DEBUG)
import kashgari
from kashgari.embeddings import BERTEmbedding
from kashgari.corpus import ChineseDailyNerCorpus
from kashgari.tasks.labeling import BLSTMModel
from kashgari.utils import convert_to_multi_gpu_model

train_x, train_y = ChineseDailyNerCorpus.load_data('train', shuffle=False)
test_x, test_y = ChineseDailyNerCorpus.load_data('test', shuffle=False)
valid_x, valid_y = ChineseDailyNerCorpus.load_data('valid', shuffle=False)

train_count = int(len(train_y)*0.1)
test_count = int(len(test_y)*0.1)
valid_count = int(len(valid_x)*0.1)

train_x, train_y = train_x[:train_count], train_y[:train_count]
test_x, test_y = test_x[:test_count], test_y[:test_count]
valid_x, valid_y = valid_x[:valid_count], valid_y[:valid_count]

embedding = BERTEmbedding('/home/hahahu/projects/models/bert-base-chinese', task=kashgari.LABELING, sequence_length=100, layer_nums=4)
model = BLSTMModel(embedding)

# You do not have to explicitly call model.build_model() here
model = convert_to_multi_gpu_model(model, 2, train_x, train_y)
model.fit(train_x, train_y, valid_x, valid_y, batch_size=64, epochs=10)

model.evaluate(test_x, test_y, batch_size=512, debug_info=True)
```