### PR TITLE
:bug: fix typo caused bug in DPCNN & modify its unit test to fit its using scenario.

### DIFF
--- a/kashgari/tasks/classification/dpcnn_model.py
+++ b/kashgari/tasks/classification/dpcnn_model.py
@@ -166,6 +166,8 @@ class DPCNN_Model(BaseClassificationModel):
         tensor_out = self.conv_block(tensor_out, **config['conv_block'])
         # build the above pyramid layers while `steps > 2`
         seq_len = tensor_out.shape[1].value
+        if seq_len is None:
+            raise ValueError('`sequence_length` should be explicitly assigned, but it is `None`.')
         for i in range(floor(log2(seq_len)) - 2):
             tensor_out = self.resnet_block(tensor_out, stage=i + 1,
                                            **config['resnet_block'])

--- a/kashgari/tasks/classification/dpcnn_model.py
+++ b/kashgari/tasks/classification/dpcnn_model.py
@@ -21,6 +21,10 @@ from kashgari.tasks.classification.base_model import BaseClassificationModel
 
 
 class DPCNN_Model(BaseClassificationModel):
+    '''
+    This implementation of DPCNN requires a clear declared sequence length.
+    So sequences input in should be padded or cut to a given length in advance.
+    '''
 
     @classmethod
     def get_default_hyper_parameters(cls) -> Dict[str, Dict[str, Any]]:
@@ -152,7 +156,7 @@ class DPCNN_Model(BaseClassificationModel):
             L.Dense(output_dim, **config['activation'])
         ]
 
-        tensor_out = embed_model.inputs
+        tensor_out = embed_model.output
 
         # build region tensors
         for layer in layers_region:

--- a/tests/classification/test_bi_lstm.py
+++ b/tests/classification/test_bi_lstm.py
@@ -111,7 +111,7 @@ class TestBi_LSTM_Model(unittest.TestCase):
                 if isinstance(value, bool):
                     pass
                 elif isinstance(value, int):
-                    hyper_params[layer][key] = value + 15 if value > 64 else value
+                    hyper_params[layer][key] = value + 15 if value >= 64 else value
         model = self.model_class(embedding=w2v_embedding_variable_len,
                                  hyper_parameters=hyper_params)
         model.fit(valid_x, valid_y, epochs=1)

--- a/tests/classification/test_dpcnn.py
+++ b/tests/classification/test_dpcnn.py
@@ -18,5 +18,19 @@ class TestDPCNN_Model(base.TestBi_LSTM_Model):
         cls.model_class = DPCNN_Model
 
 
+    def test_custom_hyper_params(self):
+        hyper_params = self.model_class.get_default_hyper_parameters()
+
+        for layer, config in hyper_params.items():
+            for key, value in config.items():
+                if isinstance(value, bool):
+                    pass
+                elif isinstance(value, int):
+                    hyper_params[layer][key] = value + 15 if value >= 64 else value
+        model = self.model_class(embedding=base.w2v_embedding,
+                                 hyper_parameters=hyper_params)
+        model.fit(base.valid_x, base.valid_y, epochs=1)
+        assert True
+
 if __name__ == "__main__":
     print("Hello world")


### PR DESCRIPTION
If set `sequence_length` of embedding model to `None`, it will cause the DPCNN model works improperly.
So the unit test is modified to by pass this situation.