### PR TITLE
Fixing evaluate function where list has int instead of str

### DIFF
--- a/kashgari/tasks/labeling/base_model.py
+++ b/kashgari/tasks/labeling/base_model.py
@@ -94,15 +94,14 @@ class BaseLabelingModel(BaseModel):
         """
         y_pred = self.predict(x_data, batch_size=batch_size)
         y_true = [seq[:len(y_pred[index])] for index, seq in enumerate(y_data)]
-
+        
         new_y_pred = []
         for x in y_pred:
             new_y_pred.append([str(i) for i in x])
         new_y_true = []
         for x in y_true:
             new_y_true.append([str(i) for i in x])
-                
-
+            
         if debug_info:
             for index in random.sample(list(range(len(x_data))), 5):
                 logging.debug('------ sample {} ------'.format(index))

--- a/kashgari/tasks/labeling/base_model.py
+++ b/kashgari/tasks/labeling/base_model.py
@@ -105,6 +105,44 @@ class BaseLabelingModel(BaseModel):
         print(classification_report(y_true, y_pred, digits=digits))
         return report
 
+    def new_evaluate(self,
+                 x_data,
+                 y_data,
+                 batch_size=None,
+                 digits=4,
+                 debug_info=False) -> Tuple[float, float, Dict]:
+        """
+        Build a text report showing the main classification metrics.
+
+        Args:
+            x_data:
+            y_data:
+            batch_size:
+            digits:
+            debug_info:
+
+        Returns:
+
+        """
+        temp_y_pred = self.predict(x_data, batch_size=batch_size)
+        temp_y_true = [seq[:len(y_pred[index])] for index, seq in enumerate(y_data)]
+        
+        y_pred, y_true = [], []
+        for x in temp_y_pred:
+            y_pred.append([str(i) for i in x])
+        for x in temp_y_true:
+            y_true.append([str(i) for i in x])
+        
+        if debug_info:
+            for index in random.sample(list(range(len(x_data))), 5):
+                logging.debug('------ sample {} ------'.format(index))
+                logging.debug('x      : {}'.format(x_data[index]))
+                logging.debug('y_true : {}'.format(y_true[index]))
+                logging.debug('y_pred : {}'.format(y_pred[index]))
+        report = classification_report(y_true, y_pred, digits=digits)
+        print(classification_report(y_true, y_pred, digits=digits))
+        return report
+    
     def build_model_arc(self):
         raise NotImplementedError
 

--- a/kashgari/tasks/labeling/base_model.py
+++ b/kashgari/tasks/labeling/base_model.py
@@ -94,14 +94,14 @@ class BaseLabelingModel(BaseModel):
         """
         y_pred = self.predict(x_data, batch_size=batch_size)
         y_true = [seq[:len(y_pred[index])] for index, seq in enumerate(y_data)]
-        
+
         new_y_pred = []
         for x in y_pred:
             new_y_pred.append([str(i) for i in x])
         new_y_true = []
         for x in y_true:
             new_y_true.append([str(i) for i in x])
-            
+
         if debug_info:
             for index in random.sample(list(range(len(x_data))), 5):
                 logging.debug('------ sample {} ------'.format(index))

--- a/kashgari/tasks/labeling/base_model.py
+++ b/kashgari/tasks/labeling/base_model.py
@@ -115,6 +115,7 @@ class BaseLabelingModel(BaseModel):
     def build_model_arc(self):
         raise NotImplementedError
 
+
 if __name__ == "__main__":
     logging.basicConfig(level=logging.DEBUG)
     from kashgari.tasks.labeling import BiLSTM_Model

--- a/kashgari/tasks/labeling/base_model.py
+++ b/kashgari/tasks/labeling/base_model.py
@@ -92,38 +92,6 @@ class BaseLabelingModel(BaseModel):
         Returns:
 
         """
-        y_pred = self.predict(x_data, batch_size=batch_size)
-        y_true = [seq[:len(y_pred[index])] for index, seq in enumerate(y_data)]
-
-        if debug_info:
-            for index in random.sample(list(range(len(x_data))), 5):
-                logging.debug('------ sample {} ------'.format(index))
-                logging.debug('x      : {}'.format(x_data[index]))
-                logging.debug('y_true : {}'.format(y_true[index]))
-                logging.debug('y_pred : {}'.format(y_pred[index]))
-        report = classification_report(y_true, y_pred, digits=digits)
-        print(classification_report(y_true, y_pred, digits=digits))
-        return report
-
-    def new_evaluate(self,
-                 x_data,
-                 y_data,
-                 batch_size=None,
-                 digits=4,
-                 debug_info=False) -> Tuple[float, float, Dict]:
-        """
-        Build a text report showing the main classification metrics.
-
-        Args:
-            x_data:
-            y_data:
-            batch_size:
-            digits:
-            debug_info:
-
-        Returns:
-
-        """
         temp_y_pred = self.predict(x_data, batch_size=batch_size)
         temp_y_true = [seq[:len(y_pred[index])] for index, seq in enumerate(y_data)]
         
@@ -132,7 +100,8 @@ class BaseLabelingModel(BaseModel):
             y_pred.append([str(i) for i in x])
         for x in temp_y_true:
             y_true.append([str(i) for i in x])
-        
+                
+
         if debug_info:
             for index in random.sample(list(range(len(x_data))), 5):
                 logging.debug('------ sample {} ------'.format(index))
@@ -142,10 +111,6 @@ class BaseLabelingModel(BaseModel):
         report = classification_report(y_true, y_pred, digits=digits)
         print(classification_report(y_true, y_pred, digits=digits))
         return report
-    
-    def build_model_arc(self):
-        raise NotImplementedError
-
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.DEBUG)

--- a/kashgari/tasks/labeling/base_model.py
+++ b/kashgari/tasks/labeling/base_model.py
@@ -92,14 +92,15 @@ class BaseLabelingModel(BaseModel):
         Returns:
 
         """
-        temp_y_pred = self.predict(x_data, batch_size=batch_size)
-        temp_y_true = [seq[:len(y_pred[index])] for index, seq in enumerate(y_data)]
-        
-        y_pred, y_true = [], []
-        for x in temp_y_pred:
-            y_pred.append([str(i) for i in x])
-        for x in temp_y_true:
-            y_true.append([str(i) for i in x])
+        y_pred = self.predict(x_data, batch_size=batch_size)
+        y_true = [seq[:len(y_pred[index])] for index, seq in enumerate(y_data)]
+
+        new_y_pred = []
+        for x in y_pred:
+            new_y_pred.append([str(i) for i in x])
+        new_y_true = []
+        for x in y_true:
+            new_y_true.append([str(i) for i in x])
                 
 
         if debug_info:

--- a/kashgari/tasks/labeling/base_model.py
+++ b/kashgari/tasks/labeling/base_model.py
@@ -112,6 +112,9 @@ class BaseLabelingModel(BaseModel):
         print(classification_report(y_true, y_pred, digits=digits))
         return report
 
+    def build_model_arc(self):
+        raise NotImplementedError
+
 if __name__ == "__main__":
     logging.basicConfig(level=logging.DEBUG)
     from kashgari.tasks.labeling import BiLSTM_Model


### PR DESCRIPTION
Seqeval's classification_report function requires lists of str instead of int. This change casts all the lists into strings

https://github.com/BrikerMan/Kashgari/issues/222