### PR TITLE
Rename package

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ There are also articles and posts that illustrate how to use Kashgari:
 
 ### Requirements and Installation
 
-🎉🎉🎉 We renamed the again for consistency and clarity. From now on, it is all `kashgari`. 🎉🎉🎉
+🎉🎉🎉 We renamed again for consistency and clarity. From now on, it is all `kashgari`. 🎉🎉🎉
 
 The project is based on Python 3.6+, because it is 2019 and type hinting is cool.
 

--- a/README.md
+++ b/README.md
@@ -73,17 +73,17 @@ There are also articles and posts that illustrate how to use Kashgari:
 
 ### Requirements and Installation
 
-🎉🎉🎉 We renamed the tf.keras version as **kashgari-tf** 🎉🎉🎉
+🎉🎉🎉 We renamed the again for consistency and clarity. From now on, it is all `kashgari`. 🎉🎉🎉
 
-The project is based on TensorFlow 1.14.0 and Python 3.6+, because it is 2019 and type hinting is cool.
+The project is based on Python 3.6+, because it is 2019 and type hinting is cool.
 
-```bash
-pip install kashgari-tf
-# CPU
-pip install tensorflow==1.14.0
-# GPU
-pip install tensorflow-gpu==1.14.0
-```
+| Backend          | pypi version                           | desc           |
+| ---------------- | -------------------------------------- | -------------- |
+| TensorFlow 2.x   | `pip install 'kashgari>=2.0.0'`        | coming soon    |
+| TensorFlow 1.14+ | `pip install 'kashgari>=1.0.0,<2.0.0'` |                |
+| Keras            | `pip install 'kashgari>0.2.5,<1.0.0'`  | legacy version |
+
+[Find more info about the name changing.](https://github.com/BrikerMan/Kashgari/releases/tag/v1.0.0)
 
 ### Example Usage
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ The project is based on Python 3.6+, because it is 2019 and type hinting is cool
 | ---------------- | -------------------------------------- | -------------- |
 | TensorFlow 2.x   | `pip install 'kashgari>=2.0.0'`        | coming soon    |
 | TensorFlow 1.14+ | `pip install 'kashgari>=1.0.0,<2.0.0'` |                |
-| Keras            | `pip install 'kashgari>0.2.5,<1.0.0'`  | legacy version |
+| Keras            | `pip install 'kashgari<1.0.0'`         | legacy version |
 
 [Find more info about the name changing.](https://github.com/BrikerMan/Kashgari/releases/tag/v1.0.0)
 

--- a/kashgari/__init__.py
+++ b/kashgari/__init__.py
@@ -35,4 +35,6 @@ from kashgari import tasks
 from kashgari import utils
 from kashgari import callbacks
 
-import tensorflow as tf
+from kashgari import migeration
+
+migeration.show_migration_guide()

--- a/kashgari/migeration.py
+++ b/kashgari/migeration.py
@@ -1,0 +1,38 @@
+# encoding: utf-8
+
+# author: BrikerMan
+# contact: eliyar917@gmail.com
+# blog: https://eliyar.biz
+
+# file: migration.py
+# time: 2:31 下午
+import subprocess
+import logging
+
+
+def show_migration_guide():
+    requirements = subprocess.getoutput("pip freeze")
+    for package in requirements.splitlines():
+        package_name, package_version = package.split('==')
+        if package_name == 'kashgari-tf':
+            guide = """
+   ╭─────────────────────────────────────────────────────────────────────────────╮
+   │                                                                             │
+   │          We changed the package name for clarity and consistency.           │
+   │                     From now on, it is all `kahgari`.                       │
+   │    Changelog: https://github.com/BrikerMan/Kashgari/releases/tag/v1.0.0     │
+   │                                                                             │
+   │            | Backend          | pypi version   | desc           |           │
+   │            | ---------------- | -------------- | -------------- |           │
+   │            | TensorFlow 2.x   | kashgari 2.x.x | coming soon    |           │
+   │            | TensorFlow 1.14+ | kashgari 1.x.x |                |           │
+   │            | Keras            | kashgari 0.x.x | legacy version |           │
+   │                                                                             │
+   ╰─────────────────────────────────────────────────────────────────────────────╯
+"""
+            logging.warning(guide)
+
+
+if __name__ == "__main__":
+    show_migration_guide()
+    print("hello, world")

--- a/kashgari/migeration.py
+++ b/kashgari/migeration.py
@@ -11,19 +11,21 @@ import logging
 
 
 guide = """
-   ╭─────────────────────────────────────────────────────────────────────────────╮
-   │                                                                             │
-   │          We changed the package name for clarity and consistency.           │
-   │                     From now on, it is all `kahgari`.                       │
-   │    Changelog: https://github.com/BrikerMan/Kashgari/releases/tag/v1.0.0     │
-   │                                                                             │
-   │            | Backend          | pypi version   | desc           |           │
-   │            | ---------------- | -------------- | -------------- |           │
-   │            | TensorFlow 2.x   | kashgari 2.x.x | coming soon    |           │
-   │            | TensorFlow 1.14+ | kashgari 1.x.x |                |           │
-   │            | Keras            | kashgari 0.x.x | legacy version |           │
-   │                                                                             │
-   ╰─────────────────────────────────────────────────────────────────────────────╯
+╭─────────────────────────────────────────────────────────────────────────╮
+│ ◎ ○ ○ ░░░░░░░░░░░░░░░░░░░░░  Important Message  ░░░░░░░░░░░░░░░░░░░░░░░░│
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                         │
+│              We renamed again for consistency and clarity.              │
+│                   From now on, it is all `kashgari`.                    │
+│  Changelog: https://github.com/BrikerMan/Kashgari/releases/tag/v1.0.0   │
+│                                                                         │
+│         | Backend          | pypi version   | desc           |          │
+│         | ---------------- | -------------- | -------------- |          │
+│         | TensorFlow 2.x   | kashgari 2.x.x | coming soon    |          │
+│         | TensorFlow 1.14+ | kashgari 1.x.x |                |          │
+│         | Keras            | kashgari 0.x.x | legacy version |          │
+│                                                                         │
+╰─────────────────────────────────────────────────────────────────────────╯
 """
 
 

--- a/kashgari/migeration.py
+++ b/kashgari/migeration.py
@@ -10,12 +10,7 @@ import subprocess
 import logging
 
 
-def show_migration_guide():
-    requirements = subprocess.getoutput("pip freeze")
-    for package in requirements.splitlines():
-        package_name, package_version = package.split('==')
-        if package_name == 'kashgari-tf':
-            guide = """
+guide = """
    ╭─────────────────────────────────────────────────────────────────────────────╮
    │                                                                             │
    │          We changed the package name for clarity and consistency.           │
@@ -30,7 +25,15 @@ def show_migration_guide():
    │                                                                             │
    ╰─────────────────────────────────────────────────────────────────────────────╯
 """
-            logging.warning(guide)
+
+
+def show_migration_guide():
+    requirements = subprocess.getoutput("pip freeze")
+    for package in requirements.splitlines():
+        if '==' in package:
+            package_name, package_version = package.split('==')
+            if package_name == 'kashgari-tf':
+                logging.warning(guide)
 
 
 if __name__ == "__main__":

--- a/kashgari/version.py
+++ b/kashgari/version.py
@@ -7,4 +7,4 @@
 # file: __version__.py.py
 # time: 2019-05-20 16:32
 
-__version__ = '0.5.4'
+__version__ = '1.0.0'

--- a/mkdocs/docs/about/release-notes.md
+++ b/mkdocs/docs/about/release-notes.md
@@ -16,7 +16,7 @@ pip show kashgari-tf
 
 ## Current Release
 
-￿￿### [1.0.0] - 
+### [1.0.0] - 
 
 Unfortunately, we have to change the package name for clarity and consistency. Here is the new naming sytle.
 

--- a/mkdocs/docs/about/release-notes.md
+++ b/mkdocs/docs/about/release-notes.md
@@ -16,6 +16,31 @@ pip show kashgari-tf
 
 ## Current Release
 
+￿￿### [1.0.0] - 
+
+Unfortunately, we have to change the package name for clarity and consistency. Here is the new naming sytle.
+
+| Backend          | pypi version   | desc           |
+| ---------------- | -------------- | -------------- |
+| TensorFlow 2.x   | kashgari 2.x.x | coming soon    |
+| TensorFlow 1.14+ | kashgari 1.x.x |                |
+| Keras            | kashgari 0.x.x | legacy version |
+
+Here is how the existing versions changes
+
+| Supported Backend | Kashgari Versions | Kahgsari-tf Version |
+| ----------------- | ----------------- | ------------------- |
+| TensorFlow 2.x    | kashgari 2.x.x    | -                   |
+| TensorFlow 1.14+  | kashgari 1.0.1    | -                   |
+| TensorFlow 1.14+  | kashgari 1.0.0    | 0.5.5               |
+| TensorFlow 1.14+  | -                 | 0.5.4               |
+| TensorFlow 1.14+  | -                 | 0.5.3               |
+| TensorFlow 1.14+  | -                 | 0.5.2               |
+| TensorFlow 1.14+  | -                 | 0.5.1               |
+| Keras (legacy)    | kashgari 0.2.6    | -                   |
+| Keras (legacy)    | kashgari 0.2.5    | -                   |
+| Keras (legacy)    | kashgari 0.x.x    | -                   |
+
 ### [0.5.4] - 2019.09.30
 
 - ✨ Add shuffle parameter to fit function ([#249])
@@ -113,6 +138,7 @@ pip show kashgari-tf
 - fix classification model evaluate result output
 - change test settings
 
+[1.0.0]: https://github.com/BrikerMan/Kashgari/compare/v0.5.4...v1.0.0
 [0.5.4]: https://github.com/BrikerMan/Kashgari/compare/v0.5.3...v0.5.4
 [0.5.3]: https://github.com/BrikerMan/Kashgari/compare/v0.5.2...v0.5.3
 [0.5.2]: https://github.com/BrikerMan/Kashgari/compare/v0.5.1...v0.5.2

--- a/mkdocs/docs/index.md
+++ b/mkdocs/docs/index.md
@@ -64,7 +64,7 @@ There are also articles and posts that illustrate how to use Kashgari:
 
 ### Requirements and Installation
 
-🎉🎉🎉 We renamed the again for consistency and clarity. From now on, it is all `kashgari`. 🎉🎉🎉
+🎉🎉🎉 We renamed again for consistency and clarity. From now on, it is all `kashgari`. 🎉🎉🎉
 
 The project is based on Python 3.6+, because it is 2019 and type hinting is cool.
 

--- a/mkdocs/docs/index.md
+++ b/mkdocs/docs/index.md
@@ -64,17 +64,17 @@ There are also articles and posts that illustrate how to use Kashgari:
 
 ### Requirements and Installation
 
-🎉🎉🎉 We renamed the tf.keras version as **kashgari-tf** 🎉🎉🎉
+🎉🎉🎉 We renamed the again for consistency and clarity. From now on, it is all `kashgari`. 🎉🎉🎉
 
-The project is based on TenorFlow 1.14.0 and Python 3.6+, because it is 2019 and type hints is cool.
+The project is based on Python 3.6+, because it is 2019 and type hinting is cool.
 
-```bash
-pip install kashgari-tf
-# CPU
-pip install tensorflow==1.14.0
-# GPU
-pip install tensorflow-gpu==1.14.0
-```
+| Backend          | pypi version                           | desc           |
+| ---------------- | -------------------------------------- | -------------- |
+| TensorFlow 2.x   | `pip install 'kashgari>=2.0.0'`        | coming soon    |
+| TensorFlow 1.14+ | `pip install 'kashgari>=1.0.0,<2.0.0'` |                |
+| Keras            | `pip install 'kashgari>0.2.5,<1.0.0'`  | legacy version |
+
+[Find more info about the name changing.](https://github.com/BrikerMan/Kashgari/releases/tag/v1.0.0)
 
 ### Example Usage
 

--- a/mkdocs/docs/index.md
+++ b/mkdocs/docs/index.md
@@ -72,7 +72,7 @@ The project is based on Python 3.6+, because it is 2019 and type hinting is cool
 | ---------------- | -------------------------------------- | -------------- |
 | TensorFlow 2.x   | `pip install 'kashgari>=2.0.0'`        | coming soon    |
 | TensorFlow 1.14+ | `pip install 'kashgari>=1.0.0,<2.0.0'` |                |
-| Keras            | `pip install 'kashgari>0.2.5,<1.0.0'`  | legacy version |
+| Keras            | `pip install 'kashgari<1.0.0'`         | legacy version |
 
 [Find more info about the name changing.](https://github.com/BrikerMan/Kashgari/releases/tag/v1.0.0)
 

--- a/setup.tf.py
+++ b/setup.tf.py
@@ -35,7 +35,7 @@ def find_version(*file_paths):
     raise RuntimeError("Unable to find version string.")
 
 
-__name__ = 'kashgari'
+__name__ = 'kashgari-tf'
 __author__ = "BrikerMan"
 __copyright__ = "Copyright 2018, BrikerMan"
 __credits__ = []
@@ -49,7 +49,7 @@ __description__ = 'Simple, Keras-powered multilingual NLP framework,' \
                   ' part-of-speech tagging (PoS) and text classification tasks. ' \
                   'Includes BERT, GPT-2 and word2vec embedding.'
 
-__version__ = find_version('kashgari', 'version.py')
+__version__ = '0.5.5'
 README = (HERE / "README.md").read_text(encoding='utf-8')
 
 with codecs.open('requirements.txt', 'r', 'utf8') as reader:


### PR DESCRIPTION
Unfortunately, we have to change the package name for clarity and consistency. Here is the new naming sytle.

| Backend          | pypi version   | desc           |
| ---------------- | -------------- | -------------- |
| TensorFlow 2.x   | kashgari 2.x.x | coming soon    |
| TensorFlow 1.14+ | kashgari 1.x.x |                |
| Keras            | kashgari 0.x.x | legacy version |

Here is how the existing versions changes

| Supported Backend | Kashgari Versions | Kahgsari-tf Version |
| ----------------- | ----------------- | ------------------- |
| TensorFlow 2.x    | kashgari 2.x.x    | -                   |
| TensorFlow 1.14+  | kashgari 1.0.1    | -                   |
| TensorFlow 1.14+  | kashgari 1.0.0    | 0.5.5               |
| TensorFlow 1.14+  | -                 | 0.5.4               |
| TensorFlow 1.14+  | -                 | 0.5.3               |
| TensorFlow 1.14+  | -                 | 0.5.2               |
| TensorFlow 1.14+  | -                 | 0.5.1               |
| Keras (legacy)    | kashgari 0.2.6    | -                   |
| Keras (legacy)    | kashgari 0.2.5    | -                   |
| Keras (legacy)    | kashgari 0.x.x    | -                   |