### PR TITLE
ERROR when saving modle in windos10

### DIFF
--- a/kashgari/tasks/abs_task_model.py
+++ b/kashgari/tasks/abs_task_model.py
@@ -80,7 +80,7 @@ class ABCTaskModel(ABC):
         pathlib.Path(model_path).mkdir(exist_ok=True, parents=True)
         model_path = os.path.abspath(model_path)
 
-        with open(os.path.join(model_path, 'model_config.json'), 'w') as f:
+        with open(os.path.join(model_path, 'model_config.json'), 'w', encoding='utf8') as f:
             f.write(json.dumps(self.to_dict(), indent=2, ensure_ascii=False))
             f.close()
 


### PR DESCRIPTION
In win10 environment, the default encoding for new files is gbk. When saving the model, an error occurs: "UnicodeEncodeError: 'gbk' codec can't encode character '\xa3' in position". So it needs utf8 encoding